### PR TITLE
Update README with correct kaspa sdk path

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,3 +1,3 @@
 Requirements:
 
-- download [kaspa wasm sdk](https://github.com/kaspanet/rusty-kaspa/releases) and place `web/kaspa` inside `./public` (not the content, the folder)
+- download [kaspa wasm sdk](https://github.com/kaspanet/rusty-kaspa/releases) and place `web/kaspa` inside `./app` (not the content, the folder)


### PR DESCRIPTION
## what?
README seems wrong, this updates it.

Also `include: [path.resolve(__dirname, "./app/kaspa")],` and import statements confirms intention that wasm should be in `./kaspa` not `../public/kaspa`.
